### PR TITLE
feat: add Home Manager module and improve daemon reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,48 @@ Or run it directly without installing:
 nix run github:leriart/cava-bg
 ```
 
+### Home Manager Integration
+
+1. **Add the input to your flake:**
+```nix
+inputs = {
+  # ... other inputs
+  cava-bg.url = "github:leriart/cava-bg";
+};
+```
+
+2. **Import the module and configure:**
+```nix
+{
+  homeConfigurations."user@host" = home-manager.lib.homeManagerConfiguration {
+    pkgs = nixpkgs.legacyPackages.x86_64-linux;
+    modules = [
+      cava-bg.homeManagerModules.cava-bg # Import the module
+
+      {
+        programs.cava-bg = {
+          enable = true;
+
+          # Declarative configuration (mirrors config.toml)
+          settings = {
+            general.framerate = 60;
+            audio.bar_count = 76;
+            colors.use_gradient = true;
+            xray.enabled = false;
+          };
+
+          # Systemd user service management
+          systemd = {
+            enable = true;
+            memoryMax = "500M";
+          };
+        };
+      }
+    ];
+  };
+}
+```
+
 ### Dependencies
 Before installing from source or pre-built packages, ensure you have the following dependencies:
 - **cava**

--- a/flake.lock
+++ b/flake.lock
@@ -46,11 +46,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1776200608,
-        "narHash": "sha256-broZ6RFQr4Fv0wT73gGmzNX14A43TmTFF8g4wDKlNss=",
+        "lastModified": 1778151388,
+        "narHash": "sha256-lldMJPUeouEjO8/7aLuwhcsIw29vVihm2ZALzjiqfec=",
         "owner": "nix-community",
         "repo": "naersk",
-        "rev": "8b23250ab45c2a38cd91031aee26478ca4d0a28e",
+        "rev": "efdddff9ff4d8e7d0056d57ec67dac50f75ab8f6",
         "type": "github"
       },
       "original": {
@@ -77,11 +77,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1776548001,
-        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
+        "lastModified": 1780243769,
+        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
+        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -42,7 +42,8 @@
           postFixup = ''
             if [ -x "$out/bin/cava-bg" ]; then
               wrapProgram "$out/bin/cava-bg" \
-                --prefix LD_LIBRARY_PATH : "${pkgs.lib.makeLibraryPath runtimeDeps}"
+                --prefix LD_LIBRARY_PATH : "${pkgs.lib.makeLibraryPath runtimeDeps}" \
+                --prefix PATH : "${pkgs.lib.makeBinPath [ pkgs.cava pkgs.ffmpeg ]}"
             fi
           '';
         };

--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,7 @@
           libglvnd
           ffmpeg
           dbus
+          cava
         ];
 
         cava-bg = naersk-lib.buildPackage {

--- a/flake.nix
+++ b/flake.nix
@@ -6,6 +6,9 @@
   };
 
   outputs = { self, nixpkgs, naersk, flake-utils, ... }:
+    let
+      baseHmModule = import ./nix/home-module.nix;
+    in
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs { inherit system; };
@@ -65,5 +68,17 @@
           RUST_SRC_PATH = "${rustSrc}";
         };
       }
-    );
+    )
+    // {
+      homeManagerModules.cava-bg-base = baseHmModule;
+
+      homeManagerModules.cava-bg = { config, lib, pkgs, ... }: {
+        imports = [ baseHmModule ];
+        programs.cava-bg.package = lib.mkDefault (
+          self.packages.${pkgs.stdenv.hostPlatform.system}.default
+        );
+      };
+
+      homeManagerModule = self.homeManagerModules.cava-bg;
+    };
 }

--- a/nix/home-module.nix
+++ b/nix/home-module.nix
@@ -1,0 +1,107 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.programs.cava-bg;
+  inherit (lib)
+    types mkOption mkEnableOption mkIf mkMerge literalExpression;
+  format = pkgs.formats.toml { };
+  configFile = format.generate "cava-bg-config.toml" cfg.settings;
+in
+{
+  options.programs.cava-bg = {
+    enable = mkEnableOption "cava-bg, the X-Ray wallpaper engine for Wayland";
+
+    package = mkOption {
+      type = types.nullOr types.package;
+      default = null;
+      example = literalExpression "inputs.cava-bg.packages.${pkgs.system}.default";
+      description = ''
+        The cava-bg package to use.
+
+        This option is automatically populated when the module is imported
+        from the cava-bg flake via `homeManagerModules.cava-bg`.
+        Set manually only if you need to override the default package.
+      '';
+    };
+
+    settings = mkOption {
+      type = format.type;
+      default = { };
+      example = literalExpression ''
+        {
+          general.framerate = 60;
+          audio.bar_count = 76;
+        }
+      '';
+      description = ''
+        Declarative configuration for cava-bg, mirroring the structure of `config.toml`.
+      '';
+    };
+
+    systemd = {
+      enable = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Whether to manage the cava-bg daemon via a systemd user service.
+        '';
+      };
+
+      memoryMax = mkOption {
+        type = types.nullOr types.str;
+        default = "500M";
+        example = "1G";
+        description = ''
+          Hard memory limit for the cava-bg daemon (systemd `MemoryMax`).
+          Set to `null` or `"infinity"` to disable.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable (mkMerge [
+    {
+      assertions = [
+        {
+          assertion = cfg.package != null;
+          message = ''
+            programs.cava-bg.package must be set when enable = true.
+            This is normally handled automatically when importing the module
+            from the cava-bg flake via `inputs.cava-bg.homeManagerModules.cava-bg`.
+          '';
+        }
+      ];
+    }
+
+    {
+      home.packages = lib.optional (cfg.package != null) cfg.package;
+
+      xdg.configFile."cava-bg/config.toml" = mkIf (cfg.settings != { }) {
+        source = configFile;
+      };
+
+      systemd.user.services.cava-bg = mkIf cfg.systemd.enable {
+        Unit = {
+          Description = "Cava-BG Visualizer Daemon";
+          PartOf = [ "graphical-session.target" ];
+          After = [ "graphical-session.target" ];
+        };
+
+        Service = {
+          ExecStart = "${cfg.package}/bin/cava-bg on --debug";
+
+          ExecStop = "${cfg.package}/bin/cava-bg off";
+
+          Restart = "on-failure";
+          RestartSec = 5;
+        } // lib.optionalAttrs (cfg.systemd.memoryMax != null) {
+          MemoryMax = cfg.systemd.memoryMax;
+        };
+
+        Install = {
+          WantedBy = [ "graphical-session.target" ];
+        };
+      };
+    }
+  ]);
+}

--- a/src/app_config.rs
+++ b/src/app_config.rs
@@ -815,6 +815,7 @@ pub struct ParallaxConfig {
     pub show_visualizer: bool,
     #[serde(default)]
     pub visualizer_as_parallax_layer: bool,
+    #[serde(default)]
     pub visualizer_layer_index: usize,
     #[serde(default)]
     pub profiles_dir: Option<PathBuf>,

--- a/src/cli_help.rs
+++ b/src/cli_help.rs
@@ -6,6 +6,7 @@ pub fn print_help() {
     println!("  cava-bg on --debug                 Run in foreground debug mode (no detach)");
     println!("  cava-bg on --output <name>         Start filtered to a specific output");
     println!("  cava-bg off                        Stop the daemon");
+    println!("  cava-bg restart                    Restart the daemon");
     println!("  cava-bg status                     Show daemon + output status");
     println!("  cava-bg outputs                    List detected runtime outputs");
     println!("  cava-bg output-on --output <name>  Enable one output in config");

--- a/src/config_gui.rs
+++ b/src/config_gui.rs
@@ -535,7 +535,7 @@ impl ConfigEditorApp {
     fn daemon_status() -> DaemonStatus {
         let pid_file = Self::daemon_pid_path();
         let pid = read_pid_from_file(&pid_file);
-        let running = pid.is_some_and(process_exists);
+        let running = pid.is_some_and(|p| process_exists(p) && crate::is_cava_bg_process(p));
         DaemonStatus {
             running,
             pid,

--- a/src/main.rs
+++ b/src/main.rs
@@ -179,7 +179,7 @@ fn print_outputs(config_path: &Path) -> Result<()> {
 
 fn print_status(pid_file: &Path, config_path: &Path) -> Result<()> {
     let daemon_running = read_pid_file(pid_file)?
-        .map(process_exists)
+        .map(|pid| process_exists(pid) && is_cava_bg_process(pid))
         .unwrap_or(false);
     println!(
         "Daemon: {}",
@@ -237,6 +237,35 @@ fn process_exists(pid: i32) -> bool {
 
     let errno = std::io::Error::last_os_error().raw_os_error();
     matches!(errno, Some(libc::EPERM))
+}
+
+/// Checks if the given PID belongs to the cava-bg daemon by inspecting its command-line arguments.
+pub fn is_cava_bg_process(pid: i32) -> bool {
+    if pid <= 0 {
+        return false;
+    }
+
+    let cmdline_path = format!("/proc/{}/cmdline", pid);
+    let cmdline_bytes = match std::fs::read(&cmdline_path) {
+        Ok(bytes) => bytes,
+        Err(_) => return false,
+    };
+
+    let args: Vec<&str> = cmdline_bytes
+        .split(|&b| b == 0)
+        .filter_map(|b| std::str::from_utf8(b).ok())
+        .filter(|s| !s.is_empty())
+        .collect();
+
+    if args.len() < 3 {
+        return false;
+    }
+
+    let has_internal_flag = args.contains(&"__run");
+
+    let has_config_flag = args.contains(&"--config");
+
+    has_internal_flag && has_config_flag
 }
 
 fn read_pid_file(pid_file: &Path) -> Result<Option<i32>> {
@@ -364,13 +393,21 @@ fn check_single_instance(pid_file: &Path, debug_mode: bool) -> Result<bool> {
         }
 
         match read_pid_file(&candidate)? {
-            Some(old_pid) if process_exists(old_pid) => {
+            Some(old_pid) if process_exists(old_pid) && is_cava_bg_process(old_pid) => {
                 eprintln!(
                     "Another instance of cava-bg is already running (PID {}).",
                     old_pid
                 );
                 eprintln!("Use 'cava-bg off' to stop it.");
                 return Ok(false);
+            }
+            Some(old_pid) if process_exists(old_pid) => {
+                warn!(
+                    "Removing stale PID file {} (PID {} belongs to a different process)",
+                    candidate.display(),
+                    old_pid
+                );
+                let _ = fs::remove_file(&candidate);
             }
             Some(old_pid) => {
                 warn!(
@@ -534,6 +571,16 @@ fn kill_existing_instance(pid_file: &Path) -> Result<()> {
         let _ = fs::remove_file(&pid_path);
         println!(
             "Found stale PID file at {} (PID {} is not running). Cleaned up.",
+            pid_path.display(),
+            pid
+        );
+        return Ok(());
+    }
+
+    if !is_cava_bg_process(pid) {
+        let _ = fs::remove_file(&pid_path);
+        println!(
+            "Found stale PID file at {} (PID {} belongs to a different process). Cleaned up.",
             pid_path.display(),
             pid
         );

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,24 +78,26 @@ fn ensure_parent_dir(path: &Path) -> Result<()> {
 
 const MAX_LOG_SIZE: u64 = 1024 * 1024; // 1MB
 
-fn rotate_log_file(log_path: &Path) {
+fn rotate_log_file(log_path: &Path) -> bool {
     if let Ok(metadata) = fs::metadata(log_path) {
         if metadata.len() > MAX_LOG_SIZE {
             let rotated = PathBuf::from(format!("{}.old", log_path.display()));
-            let _ = fs::rename(log_path, &rotated);
+            return fs::rename(log_path, &rotated).is_ok();
         }
     }
+    false
 }
 
 fn rotate_daemon_log() {
     let log_path = daemon_log_path();
-    rotate_log_file(&log_path);
-    if let Ok(new_file) = OpenOptions::new().create(true).append(true).open(&log_path) {
-        let fd = new_file.into_raw_fd();
-        unsafe {
-            libc::dup2(fd, libc::STDOUT_FILENO);
-            libc::dup2(fd, libc::STDERR_FILENO);
-            libc::close(fd);
+    if rotate_log_file(&log_path) {
+        if let Ok(new_file) = OpenOptions::new().create(true).append(true).open(&log_path) {
+            let fd = new_file.into_raw_fd();
+            unsafe {
+                libc::dup2(fd, libc::STDOUT_FILENO);
+                libc::dup2(fd, libc::STDERR_FILENO);
+                libc::close(fd);
+            }
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -859,6 +859,17 @@ fn main() -> Result<()> {
         "off" | "kill" => {
             kill_existing_instance(&pid_file)?;
         }
+        "restart" => {
+            kill_existing_instance(&pid_file)?;
+            ensure_config_exists(&config_path)?;
+            if debug_mode {
+                println!("Running cava-bg in debug foreground mode (no daemon detach).");
+                println!("Daemon log file: {}", daemon_log_path().display());
+                run_foreground(config_path, pid_file, true, output_filter)?;
+            } else {
+                start_daemon(&config_path, output_filter.as_deref())?;
+            }
+        }
         "outputs" => {
             print_outputs(&config_path)?;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -257,15 +257,12 @@ pub fn is_cava_bg_process(pid: i32) -> bool {
         .filter(|s| !s.is_empty())
         .collect();
 
-    if args.len() < 3 {
+    if args.len() < 2 {
         return false;
     }
 
-    let has_internal_flag = args.contains(&"__run");
-
-    let has_config_flag = args.contains(&"--config");
-
-    has_internal_flag && has_config_flag
+    args.iter()
+        .any(|&arg| ["on", "restart", "__run"].contains(&arg))
 }
 
 fn read_pid_file(pid_file: &Path) -> Result<Option<i32>> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ use std::env;
 use std::fs;
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Write};
+use std::os::unix::io::IntoRawFd;
 use std::os::unix::process::CommandExt;
 use std::panic::{self, AssertUnwindSafe};
 use std::path::{Path, PathBuf};
@@ -73,6 +74,30 @@ fn ensure_parent_dir(path: &Path) -> Result<()> {
             .with_context(|| format!("Could not create directory {}", parent.to_string_lossy()))?;
     }
     Ok(())
+}
+
+const MAX_LOG_SIZE: u64 = 1024 * 1024; // 1MB
+
+fn rotate_log_file(log_path: &Path) {
+    if let Ok(metadata) = fs::metadata(log_path) {
+        if metadata.len() > MAX_LOG_SIZE {
+            let rotated = PathBuf::from(format!("{}.old", log_path.display()));
+            let _ = fs::rename(log_path, &rotated);
+        }
+    }
+}
+
+fn rotate_daemon_log() {
+    let log_path = daemon_log_path();
+    rotate_log_file(&log_path);
+    if let Ok(new_file) = OpenOptions::new().create(true).append(true).open(&log_path) {
+        let fd = new_file.into_raw_fd();
+        unsafe {
+            libc::dup2(fd, libc::STDOUT_FILENO);
+            libc::dup2(fd, libc::STDERR_FILENO);
+            libc::close(fd);
+        }
+    }
 }
 
 fn append_daemon_log_line(message: &str) {
@@ -558,6 +583,7 @@ fn start_daemon(config_path: &Path, output_filter: Option<&str>) -> Result<()> {
 
     let log_path = daemon_log_path();
     ensure_parent_dir(&log_path)?;
+    rotate_log_file(&log_path);
     let log_file = OpenOptions::new()
         .create(true)
         .append(true)
@@ -679,6 +705,16 @@ fn run_foreground(
 
     daemon_debug_log(debug_mode, "Signal handlers installed for SIGINT/SIGTERM");
     daemon_debug_log(debug_mode, "[DAEMON] Entering main loop...");
+
+    if !debug_mode {
+        let log_running = running.clone();
+        thread::spawn(move || {
+            while log_running.load(Ordering::SeqCst) {
+                thread::sleep(Duration::from_secs(30));
+                rotate_daemon_log();
+            }
+        });
+    }
 
     let mut restart_attempt: u64 = 0;
     while running.load(Ordering::SeqCst) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -750,11 +750,13 @@ fn run_foreground(
     daemon_debug_log(debug_mode, "Signal handlers installed for SIGINT/SIGTERM");
     daemon_debug_log(debug_mode, "[DAEMON] Entering main loop...");
 
+    rotate_daemon_log();
+
     if !debug_mode {
         let log_running = running.clone();
         thread::spawn(move || {
             while log_running.load(Ordering::SeqCst) {
-                thread::sleep(Duration::from_secs(30));
+                thread::sleep(Duration::from_secs(60));
                 rotate_daemon_log();
             }
         });


### PR DESCRIPTION
**Changes:**
- **Nix/HM:** Added `homeManagerModules.cava-bg`. Supports declarative config and optional systemd service with memory limits.
- **Daemon Safety:** Fixed PID checking to avoid killing wrong processes (checks `/proc/pid/cmdline`). Cleans up stale PID files properly.
- **Logs:** Added log rotation (1MB limit) to prevent disk fill-up.
- **CLI:** Added `cava-bg restart` command.
- **Deps(nix):** Ensured `cava` and `ffmpeg` are in PATH for the wrapped binary.